### PR TITLE
remove memcached dependency

### DIFF
--- a/sensu-plugins-memory-checks.gemspec
+++ b/sensu-plugins-memory-checks.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '1.1.0'
   s.add_runtime_dependency 'timeout',      '0.0.1'
-  s.add_runtime_dependency 'memcached',    '1.8.0'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '~> 0.30'


### PR DESCRIPTION
Hi, sensu-plugins team.

When I try to install sensu-plugins-memory-checks gem, but gem installation failed because `memcached` is not installed to my server.

I checked this gem codes, but I can't find any dependency of `memcached` gem.

So this pull req remove the dependency of memcached gem.

Thanks.
