### PR TITLE
fix gemspec order

### DIFF
--- a/sensu-plugins-memory-checks.gemspec
+++ b/sensu-plugins-memory-checks.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for checking memory'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.executables            = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-memory-checks'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '',


### PR DESCRIPTION
When I install this sensu-plugin gem, no scripts created to EXECUTABLE DIRECTORY of `gem env`.

So I investigated and fixed this problem this patch.

---

In `sensu-plugins-memory-checks.gemspec`, `executables` depends on `files`.

But [executables](https://github.com/sensu-plugins/sensu-plugins-memory-checks/compare/sensu-plugins:master...hirakiuc:fix_gemspec_order?expand=1#diff-c6f2401d921b5fffdc8e4a94a8db1c93L20)  always evaluate before [files](https://github.com/sensu-plugins/sensu-plugins-memory-checks/compare/sensu-plugins:master...hirakiuc:fix_gemspec_order?expand=1#diff-c6f2401d921b5fffdc8e4a94a8db1c93L21) evaluation.

So gemspec always configure `executables = []` and no scripts created to EXECUTABLE DIRECTORY of `gem env`.

---

This pull request fixes the order of gemspec configurations.

I install this gem contains this patch, all of scripts created to EXECUTABLE DIRECTORY of `gem env`.

Thanks.
