### PR TITLE
add wrapper for shell scripts

### DIFF
--- a/bin/check-mem.rb
+++ b/bin/check-mem.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, 'check-mem.sh')
+
+exec shell_script_path, *ARGV

--- a/bin/check-memory-pcnt.rb
+++ b/bin/check-memory-pcnt.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, 'check-memory-pcnt.sh')
+
+exec shell_script_path, *ARGV

--- a/bin/check-swap-percentage.rb
+++ b/bin/check-swap-percentage.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, 'check-swap-percentage.sh')
+
+exec shell_script_path, *ARGV

--- a/bin/check-swap.rb
+++ b/bin/check-swap.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, 'check-swap.sh')
+
+exec shell_script_path, *ARGV

--- a/sensu-plugins-memory-checks.gemspec
+++ b/sensu-plugins-memory-checks.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for checking memory'
   s.email                  = '<sensu-users@googlegroups.com>'
-  s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
+  s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-memory-checks'
   s.license                = 'MIT'


### PR DESCRIPTION
By default gem add a wrapper in /usr/local/bin for all binary present in gemspec file (s.executables variable in our gemspec). But this wrapper doesn't work with shell script because it was executed with load function. So should do another wrapper to call shell script with an exec function.
