### PR TITLE
Fix check-ram logic

### DIFF
--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -62,11 +62,11 @@ class CheckRAM < Sensu::Plugin::Check::CLI
     else
       unknown 'invalid percentage' if config[:crit] > 100 || config[:warn] > 100
 
-      percents_left = free_ram * 100 / total_ram
-      message "#{percents_left}% free RAM left"
+      percents_used = 100 - (free_ram * 100 / total_ram)
+      message "#{percents_used}% RAM used"
 
-      critical if percents_left < config[:crit]
-      warning if percents_left < config[:warn]
+      critical if percents_used > config[:crit]
+      warning if percents_used > config[:warn]
       ok
     end
   end


### PR DESCRIPTION
It's more common to check if RAM usage is higher than X percents than check if free RAM is lower than X percent.

swap-percentage checks in this way - so it is bad that two scripts in the same repo have oposite logic.

I know it would propably be pain in the ass change it here - maybe create check-ram-percentage.rb as wrapper to check-ram will be better way (and then only execute check-ram with -w (100-value) -c (100-value)).
