### PR TITLE
fix mb math

### DIFF
--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -79,9 +79,9 @@ class CheckRAM < Sensu::Plugin::Check::CLI
 
     if config[:megabytes]
       # free_ram is returned in Bytes. see: https://github.com/threez/ruby-vmstat/blob/master/lib/vmstat/memory.rb
-      free_ram /= 1024 / 1024
-      used_ram /= 1024 / 1024
-      total_ram /= 1024 / 1024
+      free_ram /= 1024 * 1024
+      used_ram /= 1024 * 1024
+      total_ram /= 1024 * 1024
       if config[:free]
         ram = free_ram
         message "#{ram} megabytes of RAM left"

--- a/lib/sensu-plugins-memory-checks/version.rb
+++ b/lib/sensu-plugins-memory-checks/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsMemoryChecks
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 7
+    PATCH = 8
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
As per: https://github.com/sensu-plugins/sensu-plugins-memory-checks/issues/19

This appear to be the correct output:

```
$ bin/check-ram.rb --megabytes 100
CheckRAM OK: 13946 megabytes of RAM left
```
