### PR TITLE
Version number on RHEL 7 is 7th field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [0.0.8] - 2015-09-29
 ### Fixed
 - check-ram.rb incorrectly calculated ram
+- check-memory.sh, support for RHEL 7.
 
 ## [0.0.7] - 2015-08-11
 ### Fixed

--- a/bin/check-memory.sh
+++ b/bin/check-memory.sh
@@ -46,7 +46,7 @@ if [[ -f /etc/redhat-version && `awk '{print $3}' /etc/redhat-release` =~ ^2[0-9
    redhat_version=1
 elif [[ -f /etc/redhat-version && `awk '{print $7}' /etc/redhat-version` =~ ^7\.[0-9]{1} ]]; then
    redhat_version=1
-elif [[ -f /etc/redhat-release && `awk '{print $4}' /etc/redhat-release` =~ ^7\.[0-9]{1} ]]; then
+elif [[ -f /etc/redhat-release && `awk '{print $7}' /etc/redhat-release` =~ ^7\.[0-9]{1} ]]; then
    redhat_version=1
 else
    redhat_version=0

--- a/bin/check-memory.sh
+++ b/bin/check-memory.sh
@@ -42,11 +42,11 @@ WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
 # validate fedora > 20 and rhel > 7.0 and centos > 7.0
-if [[ -f /etc/redhat-version && `awk '{print $3}' /etc/redhat-release` =~ ^2[0-9]{1} ]]; then
+if [[ -f /etc/redhat-version && `egrep "2[0-9]{1}" /etc/redhat-release` ]]; then
    redhat_version=1
-elif [[ -f /etc/redhat-version && `awk '{print $7}' /etc/redhat-version` =~ ^7\.[0-9]{1} ]]; then
+elif [[ -f /etc/redhat-version && `egrep "7\.[0-9]{1}" /etc/redhat-version` ]]; then
    redhat_version=1
-elif [[ -f /etc/redhat-release && `awk '{print $7}' /etc/redhat-release` =~ ^7\.[0-9]{1} ]]; then
+elif [[ -f /etc/redhat-release && `egrep "7\.[0-9]{1}" /etc/redhat-release` ]]; then
    redhat_version=1
 else
    redhat_version=0


### PR DESCRIPTION
The 4th field gives "Linux" whereas the 7.2 version number is on the 7th field. This is causing a `MEMORY - UKNOWN` issue for our RHEL 7 machines.

```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.2 (Maipo)
$ awk '{print $4}' /etc/redhat-release
Linux
$ awk '{print $7}' /etc/redhat-release
7.2
```
