### PR TITLE
Fix memory calculation when < 1% of memory is free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased][unreleased]
 
+## [0.0.10] - 2016-02-23
+### Fixed
+- `check-memory-percent.sh` returned "MEM UNKNOWN" when less than 1% of memory was free
+
 ## [0.0.9] - 2016-02-05
 ### Added
 - new certs

--- a/bin/check-memory-percent.sh
+++ b/bin/check-memory-percent.sh
@@ -3,8 +3,6 @@
 # Evaluate free system memory from Linux based systems based on percentage
 # This was forked from Sensu Community Plugins
 #
-# Requires: bc
-#
 # Date: 2007-11-12
 # Author: Thomas Borger - ESG
 # Date: 2012-04-02
@@ -13,6 +11,8 @@
 # Modified: Mario Harvey - Zumetrics
 # Date: 2015-01-10
 # Modified Ollie Armstrong <ollie@armstrong.io>
+# Date: 2016-02-15
+# Modified: J. Brandt Buckley <brandt.buckley@sendgrid.com>
 
 # get arguments
 
@@ -55,7 +55,7 @@ if [ $? -ne 0 ];
   FreeMem=$(free -m | grep Mem | awk '{ print $7 }')
 fi
 #Get percentage of free memory
-FreePer=$(echo "scale=3; $FreeMem / $TotalMem * 100" | bc -l| cut -d "." -f1)
+FreePer=$(awk -v total="$TotalMem" -v free="$FreeMem" 'BEGIN { printf("%-10f\n", (free / total) * 100) }' | cut -d. -f1)
 #Get actual memory usage percentage by subtracting free memory percentage from 100
 UsedPer=$((100-$FreePer))
 


### PR DESCRIPTION
When memory dipped below 1% free, `check-memory-percent.sh` returned "MEM UNKNOWN" instead of "CRITICAL".

The reason is because `bc` returns floating point values without a leading zero by default.

Example:

```
[brandt@absinthe ~]# echo "scale=3; 1 / 1000 * 100" | bc -l| cut -d "." -f1

[brandt@absinthe ~]#
```

To fix this, I've substituted `bc` for `awk`.

This also makes the check work out-of-the-box on CentOS Minimal (`bc` is not included by default, but `awk` is).
