### PR TITLE
remove runtime dependency of `vmstat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased][unreleased]
 
+## [1.0.0] - 2016-03-06
+### Changed
+- removed `vmstat` from a runtime dependency to remove gcc dependency.
+- added documentation about how you would install the required runtime dependencies if you are using `bin/check-ram.rb`.
+- added some checking to `bin/check-ram.rb` to be handled appropriately if you do not install the required dependencies.
+
 ## [0.0.9] - 2016-02-05
 ### Added
 - new certs

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-memory-checks.gemspec
 gemspec
-gem 'vmstat', '2.1.0'

--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
+### `bin/check-ram.rb`
+
+Ruby does not have a good native way without the use of c extensions to grab information on memory usage (outside of running shell commands and parsing out). Because of this `check-ram.rb` uses a gem called `vmstat` which has a somewhat annoying dependency on a gcc to compile the c extensions. In order to not force people to install gcc if they are not using `check-ram.rb` we do not install it by default, and is up to the user to make sure that they install it. This requires two steps and can vary based on your distribution and ruby set up:
+- Install `gcc`. If you are on a debian based system it is located in the `build-essential` package.
+- Install `vmstat` gem into the path that sensu gems are expected to run from: this is typically.
+
 ## Notes

--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -14,10 +14,14 @@
 # DEPENDENCIES:
 #   gem: sensu-plugin
 #   gem: vmstat
+#   compiler: gcc
 #
 # USAGE:
 #   check-ram.rb --help
 #
+# EXTRA INSTALL INSTRUCTIONS:
+#   You must install gcc. This is needed to compile the vmstat gem
+#   which you must put in a path that sensu can reach.
 # NOTES:
 #   The default behavior is to check % of RAM free. This can easily
 #   be overwritten via args please see `check-ram.rb --help` for details
@@ -64,6 +68,13 @@ class CheckRAM < Sensu::Plugin::Check::CLI
          default: 5
 
   def run
+    begin
+      require 'vmstat'
+    rescue LoadError => e
+      raise unless e.message =~ /vmstat/
+      unknown "Error unable to load vmstat gem: #{e}"
+    end
+
     # calculating free and used ram based on: https://github.com/threez/ruby-vmstat/issues/4 to emulate free -m
     mem = Vmstat.snapshot.memory
     free_ram = mem.inactive_bytes + mem.free_bytes

--- a/lib/sensu-plugins-memory-checks/version.rb
+++ b/lib/sensu-plugins-memory-checks/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsMemoryChecks
   module Version
-    MAJOR = 0
+    MAJOR = 1
     MINOR = 0
-    PATCH = 9
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-memory-checks.gemspec
+++ b/sensu-plugins-memory-checks.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsMemoryChecks::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'vmstat', '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -47,5 +46,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'vmstat',                    '~> 2.1.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
This is to address: https://github.com/sensu-plugins/sensu-plugins-memory-checks/issues/22

I wish there was a better way to do this but I cant think of any. Open to any suggestions, this is more of a proposal than being ready to go.

I have not tested and will be kind of harder for me to test because I would have to custom build something from scratch because all our automation has gcc installed via the `build-essentials` package.

Also the reason it is a full release is because its a breaking change with no backwards compatibility, rather than a minor, or patch.
