### PR TITLE
Only require vmstat on `#run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- `check-ram.rb`: Only require vmstat on `#run`
 
 ## [2.0.0] - 2016-10-14
 ### Fixed

--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -34,7 +34,6 @@
 #   for details.
 #
 require 'sensu-plugin/check/cli'
-require 'vmstat'
 
 class CheckRAM < Sensu::Plugin::Check::CLI
   option :megabytes,


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

- `check-ram.rb`: Only require vmstat on `#run`

  vmstat is being required twice: at the top of the file, and then inside
the method `#run`. In order for `check-ram.rb` not to fail, vmstat
should only be required inside the method `#run`.

#### Known Compatablity Issues
