### PR TITLE
Only require vmstat at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- `check-ram.rb`: Only require vmstat at the top
 
 ## [2.0.0] - 2016-10-14
 ### Fixed

--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -69,13 +69,6 @@ class CheckRAM < Sensu::Plugin::Check::CLI
          default: 5
 
   def run
-    begin
-      require 'vmstat'
-    rescue LoadError => e
-      raise unless e.message =~ /vmstat/
-      unknown "Error unable to load vmstat gem: #{e}"
-    end
-
     # calculating free and used ram based on: https://github.com/threez/ruby-vmstat/issues/4 to emulate free -m
     mem = Vmstat.snapshot.memory
     free_ram = mem.inactive_bytes + mem.free_bytes


### PR DESCRIPTION
Alternative to #48 

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

- `check-ram.rb`: Only require vmstat at the top
  
  There is no need to require vmstat inside `#run` if it is already required at the top.

#### Known Compatablity Issues


