### PR TITLE
Set environment variable LANG=C for reliable output parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- set environment varable LANG=C for reliable output parsing
 ### Fixed
 - `check-ram.rb`: Only require vmstat on `#run`
 

--- a/bin/check-memory-percent.sh
+++ b/bin/check-memory-percent.sh
@@ -14,6 +14,9 @@
 # Date: 2016-02-15
 # Modified: J. Brandt Buckley <brandt.buckley@sendgrid.com>
 
+# set lang
+LANG=C
+
 # get arguments
 
 # #RED

--- a/bin/check-memory.sh
+++ b/bin/check-memory.sh
@@ -10,6 +10,9 @@
 # The memory check is done with following command line:
 # free -m | grep buffers/cache | awk '{ print $4 }'
 
+# set lang
+LANG=C
+
 # get arguments
 
 # #RED

--- a/bin/check-swap.sh
+++ b/bin/check-swap.sh
@@ -12,6 +12,9 @@
 # The swap check is done with following command line:
 # vmstat | tail -n1 | awk '{ print $3 }'
 
+# set lang
+LANG=C
+
 # get arguments
 
 # #RED 


### PR DESCRIPTION
On systems using a different locale than English the output parsing of `free` does not work, since it depends on the output being in the English language. Explicitly setting LANG=C helps to ensure the output can be parsed regardless of the locale settings.