### PR TITLE
fixes #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- to better address linux users expecting free ram to not include buffer cache we bumped to a new version of vmstat to get the new functionality. As this is not installed you must manually install `2.3.0`. This will use the field `MemAvailable` in `/proc/meminfo`. It maintains its backwards compatibility to keep existing behavior.
 
 ## [2.0.0] - 2017-01-17
 ### Breaking Changes
-- The hardcoded default thresholds of 90% warn 95% critical in `check-ram.rb` when using the `--used` option 
+- The hardcoded default thresholds of 90% warn 95% critical in `check-ram.rb` when using the `--used` option
   have been removed so custom thresholds can be passed. To obtain identical behavior configure the check
   like `check-ram.rb --used -w 90 -c 95`.
 - Ruby < 2.1 is no longer supported

--- a/bin/check-ram.rb
+++ b/bin/check-ram.rb
@@ -77,7 +77,11 @@ class CheckRAM < Sensu::Plugin::Check::CLI
 
     # calculating free and used ram based on: https://github.com/threez/ruby-vmstat/issues/4 to emulate free -m
     mem = Vmstat.snapshot.memory
-    free_ram = mem.inactive_bytes + mem.free_bytes
+    begin
+      free_ram = mem.available_bytes
+    rescue NoMethodError
+      free_ram = mem.inactive_bytes + mem.free_bytes
+    end
     used_ram = mem.wired_bytes + mem.active_bytes
     total_ram = mem.total_bytes
 

--- a/sensu-plugins-memory-checks.gemspec
+++ b/sensu-plugins-memory-checks.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'vmstat',                    '~> 2.1.0'
+  s.add_development_dependency 'vmstat',                    '~> 2.3.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
In a newer version of vmstat we can pull the filed `MemAvailable` from `/proc/meminfo` which is only available in linux kernels 3.14 and higher. It attempts to maintain backwards compatibility with older versions of vmstat gem.

## Pull Request Checklist

fixes #34 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Better reporting on memory free on linux

#### Known Compatablity Issues
Could possibly break on linux kernels less than 3.14? I have not tested...