### PR TITLE
adding ruby 2.4 testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -24,5 +24,4 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
-
+#### Known Compatibility Issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -28,4 +29,5 @@ deploy:
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-memory-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- ruby 2.4 testing
+
+### Fixed
+- in PR template spell "compatibility" correctly
 
 ## [2.1.0] - 2017-03-08
 ### Changed


### PR DESCRIPTION
fixed spelling of "compatibility" in pr template.

part of: https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/27

Signed-off-by: Ben Abrams <me@benabrams.it>

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
ruby 2.4 testing fix spelling in pr template.
#### Known Compatablity Issues
none
