### PR TITLE
add case if MemAvailable is existing in /proc/meminfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [3.0.3] - 2017-09-21
+### Fixed
+- metrics-memory-percent.rb, metrics-memory.rb: change 'usedWOBuffersCaches' and 'freeWOBuffersCaches' calculation to use MemAvailable in /proc/meminfo when available. (@jpoizat)
+
 ## [3.0.2] - 2017-07-31
 ### Fixed
 - check-memory-percent.rb, check-memory.rb: fix shell call response when running on non en_US locale systems (@stefan-walluhn)

--- a/bin/metrics-memory-percent.rb
+++ b/bin/metrics-memory-percent.rb
@@ -59,13 +59,20 @@ class MemoryGraphite < Sensu::Plugin::Metric::CLI::Graphite
       mem['swapTotal'] = line.split(/\s+/)[1].to_i * 1024 if line =~ /^SwapTotal/
       mem['swapFree']  = line.split(/\s+/)[1].to_i * 1024 if line =~ /^SwapFree/
       mem['dirty']     = line.split(/\s+/)[1].to_i * 1024 if line =~ /^Dirty/
+      mem['available'] = line.split(/\s+/)[1].to_i * 1024 if line =~ /^MemAvailable/
     end
 
     mem['swapUsed'] = mem['swapTotal'] - mem['swapFree']
     mem['used'] = mem['total'] - mem['free']
-    mem['usedWOBuffersCaches'] = mem['used'] - (mem['buffers'] + mem['cached'])
-    mem['freeWOBuffersCaches'] = mem['free'] + (mem['buffers'] + mem['cached'])
 
+    # if MemAvailable exist, use it to calculate "available memory"
+    if mem.key?('available')
+      mem['usedWOBuffersCaches'] = mem['total'] - mem['available']
+      mem['freeWOBuffersCaches'] = mem['available']
+    else
+      mem['usedWOBuffersCaches'] = mem['used'] - (mem['buffers'] + mem['cached'])
+      mem['freeWOBuffersCaches'] = mem['free'] + (mem['buffers'] + mem['cached'])
+    end
     # to prevent division by zero
     swptot = if mem['swapTotal'].zero?
                1

--- a/bin/metrics-memory.rb
+++ b/bin/metrics-memory.rb
@@ -55,12 +55,19 @@ class MemoryGraphite < Sensu::Plugin::Metric::CLI::Graphite
       mem['swapTotal'] = line.split(/\s+/)[1].to_i * 1024 if line =~ /^SwapTotal/
       mem['swapFree']  = line.split(/\s+/)[1].to_i * 1024 if line =~ /^SwapFree/
       mem['dirty']     = line.split(/\s+/)[1].to_i * 1024 if line =~ /^Dirty/
+      mem['available'] = line.split(/\s+/)[1].to_i * 1024 if line =~ /^MemAvailable/
     end
 
     mem['swapUsed'] = mem['swapTotal'] - mem['swapFree']
     mem['used'] = mem['total'] - mem['free']
-    mem['usedWOBuffersCaches'] = mem['used'] - (mem['buffers'] + mem['cached'])
-    mem['freeWOBuffersCaches'] = mem['free'] + (mem['buffers'] + mem['cached'])
+    # if MemAvailable exist, use it to calculate "available memory"
+    if mem.key?('available')
+      mem['usedWOBuffersCaches'] = mem['total'] - mem['available']
+      mem['freeWOBuffersCaches'] = mem['available']
+    else
+      mem['usedWOBuffersCaches'] = mem['used'] - (mem['buffers'] + mem['cached'])
+      mem['freeWOBuffersCaches'] = mem['free'] + (mem['buffers'] + mem['cached'])
+    end
     mem['swapUsedPercentage'] = 100 * mem['swapUsed'] / mem['swapTotal'] if mem['swapTotal'] > 0
 
     mem

--- a/lib/sensu-plugins-memory-checks/version.rb
+++ b/lib/sensu-plugins-memory-checks/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsMemoryChecks
   module Version
     MAJOR = 3
     MINOR = 0
-    PATCH = 2
+    PATCH = 3
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

This is related to Issue #45 (see thread)

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
Yes
- [ ] Update README with any necessary configuration snippets
N/A
- [ ] Binstubs are created if needed
N/A
- [ ] RuboCop passes
N/A
- [ ] Existing tests pass
tested on centos 6.8 (no MemAvailable field) and Ubuntu 16.04 (MemAvailable field exist)

#### Purpose

Rationnalize check and metrics for system with field MemAvailable in /proc/meminfo

#### Known Compatibility Issues

None